### PR TITLE
Fixing Trigger Priority Issue

### DIFF
--- a/FFXIV_Vibe_Plugin/App/Devices/DevicesController.cs
+++ b/FFXIV_Vibe_Plugin/App/Devices/DevicesController.cs
@@ -353,6 +353,9 @@ namespace FFXIV_Vibe_Plugin.Device {
           forceStop = true;
           this.SendCommand(command, device, 0, motorId);
           this.Logger.Debug($"Force stopping {deviceAndMotorId} because of StopAfter={StopAfter}");
+
+          // Make sure we clean the current playing trigger whgenever we're force stopping a trigger
+          this.CurrentPlayingTrigger = null;
         }
       });
       tStopAfter.Start();
@@ -394,9 +397,6 @@ namespace FFXIV_Vibe_Plugin.Device {
 
           Thread.Sleep(duration);
         }
-
-        // Make sure we clean the current playing trigger.
-        this.CurrentPlayingTrigger = null;
       });
       t.Start();
     }


### PR DESCRIPTION
Fixing Trigger Priority issue where `this.CurrentPlayingTrigger` is being cleared immediately due to Thread.sleep(duration) running with duration being 0.

Suggestion to shift logic for clearing CurrentPlayingTrigger to when force stop is being called.